### PR TITLE
Put SASS back into its own file

### DIFF
--- a/after/syntax/css.vim
+++ b/after/syntax/css.vim
@@ -340,5 +340,4 @@ if has("gui_running") || &t_Co==256
 
   autocmd CursorMoved  * silent call s:PreviewCSSColorInLine()
   autocmd CursorMovedI * silent call s:PreviewCSSColorInLine()
-  autocmd FileType sass,scss,stylus syn cluster sassCssAttributes add=@cssColors
 endif

--- a/after/syntax/sass.vim
+++ b/after/syntax/sass.vim
@@ -1,0 +1,1 @@
+syn cluster sassCssAttributes add=@cssColors


### PR DESCRIPTION
After playing around with the SASS/SCSS support, I think that SASS really does need its own file (`syntax/after/sass.vim`). This is effectively a reversion of the last couple of your commits that were related to SASS. This fixes [#2 at skammer's repository](https://github.com/skammer/vim-css-color/issues/2) in a way that works for me.

Thanks!
