### PR TITLE
Escape slashes in color pattern

### DIFF
--- a/after/syntax/css.vim
+++ b/after/syntax/css.vim
@@ -37,7 +37,7 @@ function! s:MatchColorValue(color, pattern)
   if pattern =~ '\>$' | let pattern .= '\>' | endif
 
   let group = 'cssColor' . tolower(a:color)
-  exe 'syn match' group '/'.pattern.'/ contained'
+  exe 'syn match' group '/'.escape(pattern, '/').'/ contained'
   exe 'syn cluster cssColors add='.group
   exe s:fg_color_calc
   exe 'hi' group s:color_prefix.'bg='.color s:color_prefix.'fg='.s:FGForBG(a:color)


### PR DESCRIPTION
Sass expressions like rgba(0,0,0,32/100) would cause errors by ending the regexp early.

I hope this is the right way to do it. I'm not exactly an expert with Vimscript.
