### PR TITLE
Enable richer colorizing in less files

### DIFF
--- a/after/syntax/less.vim
+++ b/after/syntax/less.vim
@@ -3,4 +3,4 @@
 
 if !( has('gui_running') || &t_Co==256 ) | finish | endif
 
-call css_color#init('css', 'lessVariableValue')
+call css_color#init('css', 'lessVariableValue,lessDefinition,lessComment')


### PR DESCRIPTION
The default `less.vim` file only colorize the variable value if it's a hex string or rgb(a) func. The ones in comments and definitions should look pretty as well. 
