### PR TITLE
CSS color support for .json files

### DIFF
--- a/after/syntax/json.vim
+++ b/after/syntax/json.vim
@@ -1,0 +1,6 @@
+" Language:     Colorful CSS Color Preview
+" Author:       Aristotle Pagaltzis <pagaltzis@gmx.de>
+
+if !( has('gui_running') || &t_Co==256 ) | finish | endif
+
+call css_color#init('css', 'jsonString')


### PR DESCRIPTION
This is to add CSS color functionality to .json files to use in combination with [vim-json](https://github.com/elzr/vim-json) etc.