### PR TITLE
Fix maps colour highlighting for ft=scss

### DIFF
--- a/after/syntax/scss.vim
+++ b/after/syntax/scss.vim
@@ -1,4 +1,4 @@
 " Language:     Colorful CSS Color Preview
 " Author:       Aristotle Pagaltzis <pagaltzis@gmx.de>
 
-call css_color#init('css', 'extended', 'scssAttribute,scssComment,scssVariableValue,sassCssAttribute,cssComment')
+call css_color#init('css', 'extended', 'scssAttribute,scssComment,scssVariableValue,scssMap,scssMapValue,sassCssAttribute,cssComment')


### PR DESCRIPTION
With the latest pulls from ap/vim-css-color, hail2u/vim-css3-syntax, and cakebaker/scss-syntax.vim, files with `filetype=scss` fail to highlight colours within maps. Setting `filetype=sass` fixes that, but breaks other syntax highlighting. Adding scssMap and scssMapValue to the SCSS attributes fixes it properly.