### PR TITLE
Added lua support (or, re-added)

### DIFF
--- a/after/syntax/lua.vim
+++ b/after/syntax/lua.vim
@@ -1,0 +1,4 @@
+" Language:     Colorful CSS Color Preview
+" Author:       Robert Perce <robert.perce@gmail.com>
+
+call css_color#init('hex', 'extended', 'luaString')


### PR DESCRIPTION
I saw 81ce955 after I did this — I haven't had any problems with this setup? Occasionally I'll have a string that has the word "red" or something that gets colored, but that's expected behavior (and honestly I kinda like it!) If there's reasons I haven't come across to keep lua support out that's fine, but it *does* work on my box. 

And since I use awesomewm and my window manager themes are just lua scripts, this particular support is very nice for me to have :)