### PR TITLE
Add 24-bit ("true") terminal color support

### DIFF
--- a/autoload/css_color.vim
+++ b/autoload/css_color.vim
@@ -43,7 +43,7 @@ for i in range(0, 255)
 	let s:hex[ printf( '%02x', i ) ] = i
 endfor
 
-if has('gui_running')
+if has('gui_running') || (has('termguicolors') && &termguicolors)
 	function! s:create_highlight(color, is_bright)
 		exe 'hi BG'.a:color 'guibg=#'.a:color 'guifg=#'.( a:is_bright ? '000000' : 'ffffff' )
 	endfunction


### PR DESCRIPTION
This conditionally enables 24-bit terminal colors for versions of Vim/NeoVim that support it, via the `termguicolors` feature and option.

Closes #47.