### PR TITLE
Fix #89: css highlight in javascript files

### DIFF
--- a/after/syntax/javascript.vim
+++ b/after/syntax/javascript.vim
@@ -6,6 +6,6 @@ if &syntax =~# '\(^\|\.\)coffee\($\|\.\)' | finish | endif
 
 " javaScriptX = default Vim syntax, jsX = https://github.com/pangloss/vim-javascript
 call css_color#init('hex', 'extended'
-	\, 'javaScriptComment,javaScriptLineComment,javaScriptStringS,javaScriptStringD'
+	\, 'javaScriptComment,javaScriptLineComment,javaScriptStringS,javaScriptStringD,'
 	\. 'jsComment,jsString,jsTemplateString,jsObjectKeyString,jsObjectStringKey,jsClassStringKey'
 	\)


### PR DESCRIPTION
Now the css color is highlighted rightly also inside of:
- jsComment
- jsString
- jsTemplateString
- jsObjectKeyString
- jsObjectStringKey
- jsClassStringKey