### PR TITLE
add support for QML

### DIFF
--- a/after/syntax/qml.vim
+++ b/after/syntax/qml.vim
@@ -1,0 +1,1 @@
+call css_color#init('css', 'extended', 'qmlStringD')


### PR DESCRIPTION
Support for color highlighting in QML: changed groups in `after/syntax/css.vim` to match QML string syntax highlighting group.