### PR TITLE
Include cssIdentifier in css recognized groups

### DIFF
--- a/after/syntax/css.vim
+++ b/after/syntax/css.vim
@@ -1,1 +1,1 @@
-call css_color#init('css', 'extended', 'cssMediaBlock,cssFunction,cssDefinition,cssAttrRegion,cssComment')
+call css_color#init('css', 'extended', 'cssIdentifier,cssMediaBlock,cssFunction,cssDefinition,cssAttrRegion,cssComment')


### PR DESCRIPTION
I found it useful in this file:

https://gitlab.gnome.org/GNOME/gitg/-/blob/master/gitg/resources/ui/style.css#L1

![Captura de pantalla de 2020-08-23 14-00-37](https://user-images.githubusercontent.com/220968/90977835-0d7eab80-e549-11ea-9fec-4b3fba3e4d64.png)

There're some colors that are greys, but others like line 23 are not recognized as light purple. Don't know the reason