### PR TITLE
add(kitty): kitty color support

### DIFF
--- a/after/syntax/kitty.vim
+++ b/after/syntax/kitty.vim
@@ -1,0 +1,1 @@
+call css_color#init('hex', 'none', 'kittyColor')


### PR DESCRIPTION
Add support for kitty colors in config file.
[PR](https://github.com/fladson/vim-kitty/pull/13) to add `kittyColor` syntax group in vim-kitty is opened

Could be great to add support for this file type

Signed-off-by: Fymyte <pierguill@gmail.com>
