### PR TITLE
update i3config for vim 8.2

### DIFF
--- a/after/syntax/i3.vim
+++ b/after/syntax/i3.vim
@@ -1,3 +1,0 @@
-" Colour => https://github.com/moon-musick/vim-i3-config-syntax
-" i3*    => https://github.com/PotatoesMaster/i3-vim-syntax
-call css_color#init('hex', 'none', 'Colour,i3SimpleString,i3Color1st,i3Color2nd,i3ColorLast')

--- a/after/syntax/i3config.vim
+++ b/after/syntax/i3config.vim
@@ -1,2 +1,2 @@
-" https://github.com/mboughaba/i3config.vim
-call css_color#init('hex', 'none', 'Color')
+" https://github.com/vim/vim/blob/master/runtime/syntax/i3config.vim
+call css_color#init('hex', 'none', 'i3ConfigColor')


### PR DESCRIPTION
Vim 8.2 ships with a i3config.vim file out-of-the-box[1]. The relevant
highlight is i3ConfigColor[2].

[1]: https://github.com/vim/vim/pull/7969
[2]: https://github.com/vim/vim/blob/master/runtime/syntax/i3config.vim

Fixes https://github.com/ap/vim-css-color/issues/94