### PR TITLE
add kittyComment to see default colors in comments

### DIFF
--- a/after/syntax/kitty.vim
+++ b/after/syntax/kitty.vim
@@ -1,1 +1,1 @@
-call css_color#init('hex', 'none', 'kittyColor')
+call css_color#init('hex', 'none', 'kittyColor,kittyComment')


### PR DESCRIPTION
This is so that you can see the default colors set in the comments of the kitty.conf file, like so:
<img width="296" alt="Schermafbeelding 2022-10-28 om 11 24 38" src="https://user-images.githubusercontent.com/2389292/198553539-6b7c93e2-1e37-4c24-8f26-cf47793e833c.png">

Also, thanks to the maintainers for this plugin; it is a really great plugin for time saving on spot checking colors :)