### PR TITLE
Honor termguicolors and terminals with t_co > 256. Fixes: #186

### DIFF
--- a/autoload/css_color.vim
+++ b/autoload/css_color.vim
@@ -3,14 +3,25 @@
 " Commit:       $Format:%H$
 " Licence:      The MIT License (MIT)
 
-if ! ( v:version >= 700 && has('syntax') && ( has('gui_running') || has('nvim') || &t_Co == 256 ) )
+if ! ( v:version >= 700 && has('syntax') && (
+			\ has('gui_running')                       ||
+			\ has('nvim')                              ||
+			\ (has('termguicolors') && &termguicolors) ||
+			\ &t_Co >= 256
+			\ ) )
 	function! css_color#init(type, keywords, groups)
 	endfunction
 	function! css_color#extend(groups)
 	endfunction
+	function! css_color#disabled()
+		return v:true
+	endfunction
 	finish
 endif
 
+function! css_color#disabled()
+	return v:false
+endfunction
 function! s:rgb2color(r,g,b)
 	" Convert 80% -> 204, 100% -> 255, etc.
 	let rgb = map( [a:r,a:g,a:b], 'v:val =~ "%$" ? ( 255 * v:val ) / 100 : v:val' )


### PR DESCRIPTION
This is a patch that fixes what I described in #186 .